### PR TITLE
Running off summary data and adding more detailed outputs

### DIFF
--- a/STAR.py
+++ b/STAR.py
@@ -93,14 +93,14 @@ def default_scoring_tiebreaker(pairwise_matrix: pd.DataFrame):
     else:
         return TrueTie(tmp)
 
-def default_runoff_tiebreaker(summar_data: SummaryData):
+def default_runoff_tiebreaker(summary_data: SummaryData):
     # Any pre-runoff ties must be resolved
-    assert len(summar_data.score_sums.index) == 2
+    assert len(summary_data.score_sums.index) == 2
 
-    a,b = summar_data.score_sums.index
-    scores = summar_data.score_sums
+    a,b = summary_data.score_sums.index
+    scores = summary_data.score_sums
     if np.isclose(scores[a], scores[b]):
-        return TrueTie(list(summar_data.score_sums.index))
+        return TrueTie(list(summary_data.score_sums.index))
     else:
         return scores.argmax()
 
@@ -111,7 +111,9 @@ def Run_STAR_Round(summary_data: SummaryData, scoring_tiebreaker=default_scoring
     
     if len(summary_data.score_sums.index) == 1:
         round_results['winners'] = summary_data.score_sums.index
-        return summary_data.score_sums.index
+        round_results['logs'].append({'top_score': summary_data.score_sums.index})
+        round_results['logs'].append({'runoff_candidates': summary_data.score_sums.index})
+        return round_results
  
     runoff_candidates = []
     while len(runoff_candidates) < 2:

--- a/STAR.py
+++ b/STAR.py
@@ -1,29 +1,60 @@
+from ast import Starred
 import pandas as pd
 import numpy as np
-
+import copy
+from typing import Union
 class InvalidElection(Exception):
     pass
 
 class TrueTie:
     def __init__(self, tied):
         self.tied = tied
-        self.elected = []
+        self.elected = [] 
+class SummaryData:
+    def __init__(self,score_hist, score_sums, pairwise_matrix, preference_matrix):
+        self.score_hist = score_hist
+        self.score_sums = score_sums
+        self.pairwise_matrix = pairwise_matrix
+        self.preference_matrix = preference_matrix
 
-def summary_data(ballots: pd.DataFrame):
+    def drop(self,candidates):
+        self.score_hist.drop(candidates, axis=0, inplace=True)
+        self.score_sums.drop(candidates, axis=0, inplace=True)
+        self.pairwise_matrix.drop(candidates, axis=0, inplace=True)
+        self.pairwise_matrix.drop(candidates, axis=1, inplace=True)
+        self.preference_matrix.drop(candidates, axis=0, inplace=True)
+        self.preference_matrix.drop(candidates, axis=1, inplace=True)
+        return self
+
+    def keep(self,candidates):
+        self.score_hist = self.score_hist.loc[candidates, :]
+        self.score_sums = self.score_sums.loc[candidates]
+        self.pairwise_matrix = self.pairwise_matrix.loc[candidates, candidates]
+        self.preference_matrix = self.preference_matrix.loc[candidates, candidates]
+        return self
+
+def get_summary_data(ballots: pd.DataFrame):
     # The below quantities can be emitted however is most useful
-    score_hist = {a : ballots[a].value_counts() for a in ballots.columns}
+    score_hist = pd.DataFrame(0, columns = range(6), index = ballots.columns)
+    for a in ballots.columns:
+        score_hist.loc[a] = ballots[a].value_counts().sort_index()
+    score_hist = score_hist.fillna(0)
+    
     score_sums = ballots.sum()
-    pairwise_matrix = { a :
-            { b : pairwise_winner(ballots, a, b) for b in ballots.columns }
-        for a in ballots.columns
-    }
-    return (score_hist, score_sums, pairwise_matrix)
+    
+    preference_matrix = pd.DataFrame(0, columns = ballots.columns, index = ballots.columns)
+    for a in ballots.columns:
+        for b in ballots.columns:
+            preference_matrix.loc[a][b] = (ballots.loc[:][a]>ballots.loc[:][b]).sum()
+    pairwise_matrix = (preference_matrix > preference_matrix.T).astype(int)
 
-def score_winners(ballots: pd.DataFrame):
+    return SummaryData(score_hist, score_sums, pairwise_matrix, preference_matrix)
+
+def score_winners(scores: pd.DataFrame):
     #Score winners
-    scores = ballots.sum()
+    # scores = ballots.sum()
     top_score = scores.max()
-    return [a for a in ballots.columns if np.isclose(scores[a], top_score)]
+    return [a for a in scores.index if np.isclose(scores[a], top_score)]
     
 def pairwise_winner(a: pd.Series, b: pd.Series):
     # Returns 1 if a is preferred to b, -1 if b is preferred to a, and 0 for a tie
@@ -35,9 +66,9 @@ def pairwise_winner(a: pd.Series, b: pd.Series):
     else:
         return 0
 
-def has_defeat(ballots: pd.DataFrame, a):
-    for b in ballots.columns:
-        if pairwise_winner(ballots[b], ballots[a]) == 1:
+def has_defeat(pairwise_matrix: pd.DataFrame, a):
+    for b in pairwise_matrix.columns:
+        if pairwise_matrix.loc[b][a] == 1:
             return 1
     return 0
 
@@ -46,101 +77,140 @@ def fivestar(ballots: pd.DataFrame):
     top_fstars = fstars.max()
     return [a for a in ballots.columns if np.isclose(fstars[a], top_fstars)]
 
-def weak_condorcet_winners(ballots: pd.DataFrame):
-    return [a for a in ballots.columns if not has_defeat(ballots, a)]
+def weak_condorcet_winners(pairwise_matrix: pd.DataFrame):
+    return [a for a in pairwise_matrix.columns if not has_defeat(pairwise_matrix, a)]
 
 ##############################################################################
 # The above functions are mainly helpers for easier reading of the main logic.
 ##############################################################################
 
-def default_scoring_tiebreaker(ballots: pd.DataFrame):
-    tmp = weak_condorcet_winners(ballots)
+def default_scoring_tiebreaker(pairwise_matrix: pd.DataFrame):
+    tmp = weak_condorcet_winners(pairwise_matrix)
     if len(tmp) == 1:
         return tmp[0]
     elif len(tmp) == 0:
-        return TrueTie(list(ballots.columns))
+        return TrueTie(list(pairwise_matrix.columns))
     else:
         return TrueTie(tmp)
 
-def default_runoff_tiebreaker(ballots: pd.DataFrame):
+def default_runoff_tiebreaker(summar_data: SummaryData):
     # Any pre-runoff ties must be resolved
-    assert len(ballots.columns) == 2
+    assert len(summar_data.score_sums.index) == 2
 
-    a,b = ballots.columns
-    scores = ballots.sum()
+    a,b = summar_data.score_sums.index
+    scores = summar_data.score_sums
     if np.isclose(scores[a], scores[b]):
-        return TrueTie(list(ballots.columns))
+        return TrueTie(list(summar_data.score_sums.index))
     else:
         return scores.argmax()
 
-def STAR(ballots: pd.DataFrame, scoring_tiebreaker=default_scoring_tiebreaker, runoff_tiebreaker=default_runoff_tiebreaker):
-    """
-        Given an election instance and optionally specified tiebreakers, return the STAR winner.
-
-        Parameters:
-            ballots (pd.DataFrame): contains a dataframe oriented such that each column name is a candidate
-                and each row is a voter's ballot. That is, the score voter A gives to candidate X is ballots[X][A]
-            
-            scoring_tiebreaker (function): Given an election instance, returns a winner according to the tiebreaker
-                or a TrueTie instance if it is not sufficiently resolute. Called during the scoring round of STAR.
-            
-            runoff_tiebreaker (function): Given an election instance, returns a winner according to the tiebreaker
-                or a TrueTie instance if it is not sufficiently resolute. Called during the runoff round of STAR.
-    """
-
-    if ballots.shape[1] < 1:
-        raise InvalidElection("Not enough candidates to fill desired number of seats")
-
+def Run_STAR_Round(summary_data: SummaryData, scoring_tiebreaker=default_scoring_tiebreaker, runoff_tiebreaker=default_runoff_tiebreaker):
     # If there is only one candidate, elect them
-    if ballots.shape[1] == 1:
-        return ballots.columns[0]
-
+    
+    round_results = {'winners':[], 'runner_up':[], 'logs':[]}
+    
+    if len(summary_data.score_sums.index) == 1:
+        round_results['winners'] = summary_data.score_sums.index
+        return summary_data.score_sums.index
+ 
     runoff_candidates = []
     while len(runoff_candidates) < 2:
 
-        eligible = ballots.drop(runoff_candidates, axis=1)
-        w = scoring_tiebreaker(ballots[score_winners(eligible)])
-        if isinstance(w, TrueTie):
+        eligible = copy.deepcopy(summary_data).drop(runoff_candidates)
+        top_scorers = score_winners(eligible.score_sums)
+        # round_results['logs'].append({'top_scorers': top_scorers})
+        if len(top_scorers)==1:
+            round_results['logs'].append({'top_score': top_scorers})
+            runoff_candidates.extend(top_scorers)
+        else:
+            round_results['logs'].append({'score_tie': top_scorers})
+            w = scoring_tiebreaker(eligible.pairwise_matrix[top_scorers][top_scorers])
+            if isinstance(w, TrueTie):
+                round_results['logs'].append({'score_true_tie': w})
 
-            if len(w.tied) == 2 and len(runoff_candidates) == 0:
-                runoff_candidates.extend(w.tied)
+                if len(w.tied) == 2 and len(runoff_candidates) == 0:
+                    runoff_candidates.extend(w.tied)
+
+                else:
+                    # In this case, the election returned a tie unresolvable by stated tiebreakers
+                    round_results['winners'] = w.tied.extend(runoff_candidates)
+                    return round_results
 
             else:
-                # In this case, the election returned a tie unresolvable by stated tiebreakers
-                w.tied.extend(runoff_candidates)
-                return w
-
-        else:
-            runoff_candidates.append(w)
+                runoff_candidates.extend(w)
     
+    round_results['logs'].append({'runoff_candidates': runoff_candidates})
     # At this point, either we have already exited or runoff_candidates contains exactly two candidates
     a,b = runoff_candidates
-    runoff_outcome = pairwise_winner(ballots[a], ballots[b])
 
-    if runoff_outcome == 1:
-        return a
-    elif runoff_outcome == -1:
-        return b
+    if summary_data.pairwise_matrix.loc[a][b] == 1:
+        round_results['winners'] = [a]
+        round_results['runner_up'] = b
+        return round_results
+    elif summary_data.pairwise_matrix.loc[b][a] == 1:
+        round_results['winners'] = [b]
+        round_results['runner_up'] = a
+        return round_results
     else:
-        return runoff_tiebreaker(ballots[runoff_candidates])
+        runoff_tiebreaker_results = runoff_tiebreaker(copy.deepcopy(summary_data).keep(runoff_candidates))
+        if runoff_tiebreaker_results == a:
+            round_results['winners'] = [a]
+            round_results['runner_up'] = b
+            return round_results
+        elif runoff_tiebreaker_results == b:
+            round_results['winners'] = [b]
+            round_results['runner_up'] = a
+            return round_results
+        else:
+            round_results['winners'] = runoff_tiebreaker_results
+            return round_results
 
-def Bloc_STAR(ballots: pd.DataFrame, numwinners: int, scoring_tiebreaker=default_scoring_tiebreaker, runoff_tiebreaker=default_runoff_tiebreaker):
-    elected = []
-    while len(elected) < numwinners:
+def STAR(input_data: Union[pd.DataFrame,SummaryData], numwinners=1, scoring_tiebreaker=default_scoring_tiebreaker, runoff_tiebreaker=default_runoff_tiebreaker):
+    """
+    Given election data and optionally specified number of winners and tiebreaker protocols, return the STAR winners.
+
+    Parameters:
+        input_data (pd.DataFrame OR SummaryData): 
+            If pd.DataFrame: contains a dataframe oriented such that each column name is a candidate
+            and each row is a voter's ballot. That is, the score voter A gives to candidate X is ballots[X][A]
+
+            if SummaryData: contains instance of SummaryData object. Would be used in the event that SummaryData 
+            is processed and summed accross multiple precincts
+
+        numwinners (int): number of winners for this eleciton
+            
+        scoring_tiebreaker (function): Given an election instance, returns a winner according to the tiebreaker
+            or a TrueTie instance if it is not sufficiently resolute. Called during the scoring round of STAR.
+            
+        runoff_tiebreaker (function): Given an election instance, returns a winner according to the tiebreaker
+            or a TrueTie instance if it is not sufficiently resolute. Called during the runoff round of STAR.
+    """
+    results = {'elected': [], 'round_results': []}
+    if isinstance(input_data,SummaryData):
+        if len(input_data.scores.index) < numwinners:
+            raise InvalidElection("Not enough candidates to fill desired number of seats")
+        summary_data = input_data
+    else:
+        if input_data.shape[1] < numwinners:
+            raise InvalidElection("Not enough candidates to fill desired number of seats")
+        summary_data = get_summary_data(input_data)
+    
+    while len(results['elected']) < numwinners:
         
-        eligible = ballots.drop(elected, axis=1)
-        w = STAR(eligible, scoring_tiebreaker=scoring_tiebreaker, runoff_tiebreaker=runoff_tiebreaker)
-        if isinstance(w, TrueTie):
+        eligible = copy.deepcopy(summary_data).drop(results['elected'])
+        round_results = Run_STAR_Round(eligible, scoring_tiebreaker=scoring_tiebreaker, runoff_tiebreaker=runoff_tiebreaker)
+        results['round_results'].append(round_results)
+        if isinstance(round_results['winners'], TrueTie):
 
-            if len(w.tied) + len(elected) <= numwinners:
+            if len(round_results['winners'].tied) + len(results['elected']) <= numwinners:
                 # If multiple candidates are tied in STAR but we have enough seats to elect them all, do so
-                elected.extend(w.tied)
+                results['elected'].extend(round_results['winners'].tied)
 
             else:
                 # In this case, the election returned a tie unresolveable by stated tiebreakers
-                w.elected.extend(elected)
-                return w
+                results['elected'].extend(round_results['winners'])
+                return results
         else:
-            elected.append(w)
+            results['elected'].extend(round_results['winners'])
     
-    return elected
+    return results

--- a/STAR_Test.py
+++ b/STAR_Test.py
@@ -5,6 +5,7 @@ Created on Thu Oct  8 12:03:26 2020
 @author: keiedmo
 """
 
+import json
 import pandas as pd
 import numpy as np
 from STAR import STAR
@@ -18,13 +19,11 @@ class STARTest(unittest.TestCase):
         tie_breaker = [[2.0,3.0,4.0,5.0,2.0,3.0,4.0,5.0,2.0,3.0,4.0,5.0]]
         all_parties = Red + blue + tie_breaker
 
-        W = 5
-        K = 5.0
         S = pd.DataFrame(all_parties, columns= Candidates) 
 
-        winner = STAR(K, W, S)
-        print(winner)   
-        self.assertEqual(winner,'A4')    
+        results = STAR(S)
+        print(json.dumps(results, indent = 2)) #TODO: write printing function to make this look good
+        self.assertEqual(results['elected'],['A4'])    
 
 
 


### PR DESCRIPTION
This adds a few things. 

First it sets the old Bloc_STAR function as the main function to run the election with the default number of winners as 1.

Second it processes summary data such as the score sums, score histograms, preference matrix, and pairwise matrix first and uses that for the rest of the election. This is a better model for others that want to use this algorithm in a real election as they wouldn't be constantly rerunning checks on all the ballots and is more readable. I'm open to a better name for summary_data, I just went off of what was there but I think we can find a more descriptive name.

Third it allows you to pass in the summary data instead of the ballots. This could help in testing weird edge case tie breakers without having to figure out how to make it work in the ballots. It would also allow you to process and sum the summary data for a bunch of precincts and pass it in to this function to determine the winners.

Fourth it outputs more detail results for each round instead of just a list of winners. This will help those using this better understand what's going on internally. I'm open to suggestions on better ways to do this. 