### PR TITLE
Fix return of index instead of name

### DIFF
--- a/STAR.py
+++ b/STAR.py
@@ -102,7 +102,7 @@ def default_runoff_tiebreaker(summary_data: SummaryData):
     if np.isclose(scores[a], scores[b]):
         return TrueTie(list(summary_data.score_sums.index))
     else:
-        return scores.argmax()
+        return scores.index[scores.argmax()]
 
 def Run_STAR_Round(summary_data: SummaryData, scoring_tiebreaker=default_scoring_tiebreaker, runoff_tiebreaker=default_runoff_tiebreaker):
     # If there is only one candidate, elect them


### PR DESCRIPTION
If candidates are tied in runoff, the tiebreaker returns an index instead of a string.

The first example I tried for the docstring returned 0:

```py
            >>> import pandas as pd
            >>> ballots = pd.DataFrame(columns=['Allie', 'Billy', 'Candace'],
                                       data=[*2*[[5,      4,       1]],
                                             *1*[[2,      5,       0]],
                                             *3*[[0,      4,       5]],])
            >>> print(ballots)
               Allie  Billy  Candace
            0      5      4        1
            1      5      4        1
            2      2      5        0
            3      0      4        5
            4      0      4        5
            5      0      4        5
            >>> print(STAR(ballots))
            0
```
