### PR TITLE
Bug fix in ties

### DIFF
--- a/STAR.py
+++ b/STAR.py
@@ -8,7 +8,7 @@ class InvalidElection(Exception):
 
 class TrueTie(set):
     def __repr__(self) -> str:
-        return 'TIE: ' + str(set(self))
+        return 'TrueTie(' + repr(set(self)) + ')'
 class SummaryData:
     def __init__(self,score_hist, score_sums, pairwise_matrix, preference_matrix):
         self.score_hist = score_hist

--- a/STAR.py
+++ b/STAR.py
@@ -95,13 +95,14 @@ def default_scoring_tiebreaker(pairwise_matrix: pd.DataFrame):
 def default_runoff_tiebreaker(summary_data: SummaryData):
     # Any pre-runoff ties must be resolved
     assert len(summary_data.score_sums.index) == 2
-
     a,b = summary_data.score_sums.index
     scores = summary_data.score_sums
-    if np.isclose(scores[a], scores[b]):
-        return TrueTie(summary_data.score_sums.index)
+    if scores[a]>scores[b]:
+        return a
+    elif scores[b]>scores[a]:
+        return b
     else:
-        return scores.index[scores.argmax()]
+        return TrueTie(summary_data.score_sums.index)
 
 def Run_STAR_Round(summary_data: SummaryData, scoring_tiebreaker=default_scoring_tiebreaker, runoff_tiebreaker=default_runoff_tiebreaker):
     # If there is only one candidate, elect them
@@ -139,6 +140,7 @@ def Run_STAR_Round(summary_data: SummaryData, scoring_tiebreaker=default_scoring
                     return round_results
 
             else:
+                round_results['logs'].append({'score_tie_winner': w})
                 runoff_candidates.extend([w])
     
     round_results['logs'].append({'runoff_candidates': runoff_candidates})
@@ -154,12 +156,15 @@ def Run_STAR_Round(summary_data: SummaryData, scoring_tiebreaker=default_scoring
         round_results['runner_up'] = a
         return round_results
     else:
+        round_results['logs'].append({'runoff_tie': runoff_candidates})
         runoff_tiebreaker_results = runoff_tiebreaker(copy.deepcopy(summary_data).keep(runoff_candidates))
         if runoff_tiebreaker_results == a:
+            round_results['logs'].append({'runoff_tie_winner': a})
             round_results['winners'] = [a]
             round_results['runner_up'] = b
             return round_results
         elif runoff_tiebreaker_results == b:
+            round_results['logs'].append({'runoff_tie_winner': b})
             round_results['winners'] = [b]
             round_results['runner_up'] = a
             return round_results

--- a/STAR_Test.py
+++ b/STAR_Test.py
@@ -147,7 +147,7 @@ class TestSTAR:
         ballots = pd.DataFrame(data=election)
         results = STAR(ballots)
         assert isinstance(results['elected'][0], TrueTie)
-        assert set(results['elected'][0].tied) == {0, 1}
+        assert results['elected'][0] == {0, 1}
 
         # 5. One highest-scoring, two or more tied for second-highest. One
         # Condorcet winner among tied (C). One is preferred in runoff (A):
@@ -218,7 +218,7 @@ class TestSTAR:
         ballots = pd.DataFrame(data=election)
         results = STAR(ballots)
         assert isinstance(results['elected'][0], TrueTie)
-        assert set(results['elected'][0].tied) == {0, 1}
+        assert results['elected'][0] == {0, 1}
 
         # 11. Three or more tied for highest-scoring. One Condorcet winner in
         # tiebreaker and two or more tied for 2nd place CW. Break tie (B or C).
@@ -239,7 +239,7 @@ class TestSTAR:
         ballots = pd.DataFrame(data=election)
         results = STAR(ballots)
         assert isinstance(results['elected'][0], TrueTie)
-        assert set(results['elected'][0].tied) == {0, 1, 2}
+        assert results['elected'][0] == {0, 1, 2}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When resolving ties we're extending the runoff candidates list with the tie winner. extend expects a list, so when the candidate names are strings it would break up the string. 

Instead of ['Allison', 'Bill'] the runoff candidates would be ['Allison', 'B', 'i', 'l', 'l'] which causes the error later on found in #16 