### PR TITLE
Package for distribution

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 env:
   FORCE_COLOR: 1
@@ -28,11 +29,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: pip install -r requirements.txt
+      run: pip install .[tests]
 
     - name: Check Python version
       run: python -V
 
     - name: Test with pytest
       run: pytest -vs
-

--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@ Python implementation of the [STAR Voting](https://www.starvoting.org/) system.
 ## Getting started
 Install the required packages
 
-`pip install -r requirements.txt`
+```shell
+pip install .
+```
 
 ## Usage
 ### Single winner STAR
 To run a single winner election create a pandas dataframe of the ballot data and pass it into the STAR function
 
-```
-from STAR import STAR
+```python
+from starpy.STAR import STAR
 import pandas as pd
 ballots = pd.DataFrame(columns=['Allie', 'Billy', 'Candace'],
                        data=[*2*[[5,      4,       0]],
@@ -22,16 +24,16 @@ print(results['elected'])
 ```
 
 ### Multi-winner Bloc STAR
-To run a multi-winner bloc STAR race, set the input parameter numwinners
-```
-results = STAR(ballots,numwinners=2)
+To run a multi-winner bloc STAR race, set the input parameter `numwinners`
+```python
+results = STAR(ballots, numwinners=2)
 ```
 
 ### Multi-winner Proportional STAR
 To run proportional STAR
-```
+```python
+from starpy.Allocated_Score import Allocated_Score 
 import pandas as pd
-from Allocated_Score import Allocated_Score 
 numwinners=2
 ballots = pd.DataFrame(columns=['Allie', 'Billy', 'Candace'],
                        data=[*2*[[5,      4,       0]],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+build-backend = "hatchling.build"
+requires = [
+  "hatchling",
+]
+
+[project]
+name = "starpy"
+version = "0.0.001"
+description = "Python implementation of the STAR Voting system"
+readme = "README.md"
+keywords = [
+  "STAR voting",
+  "voting",
+]
+license-files = { paths = [ "LICENSE" ] }
+requires-python = ">=3.9"
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: BSD License",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = [
+  "numpy>=1.21.4",
+  "pandas>=1.3.4",
+]
+optional-dependencies.tests = [
+  "pytest",
+]
+urls.Changelog = "https://github.com/Equal-Vote/starpy/releases"
+urls.Homepage = "https://github.com/Equal-Vote/starpy"
+urls.Source = "https://github.com/Equal-Vote/starpy"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-pandas>=1.3.4
-numpy>=1.21.4
-pytest>=7.1.2

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,0 @@
-from setuptools import setup, find_packages
-
-setup(
-    name='starpy',
-    version="0.0.001",
-    extras_require=dict(tests=['pytest']),
-    packages=find_packages(where='starpy'),
-    package_dir={"": "starpy"},
-)


### PR DESCRIPTION
First step for https://github.com/Equal-Vote/starpy/issues/24.

This does several things to prepare for a PyPI release, like replacing `setup.py` with `pyproject.toml`, which is the new standard for Python packaging.

This defines several things:

* A build "backend". I put the popular Hatchling here, I use this one for most things, it's extensible and standards compliant: https://pypi.org/project/hatchling/
* Define the lowest Python version supported. This tells pip or uv to only install this package on that version or higher. When we drop 3.9 later in a future release, pip/uv will then install the last version that did support 3.9, so the end user still has a working install.
* A list of "Trove" classifiers. Choose whatever you want from the list at https://pypi.org/classifiers/. These are all optional and show up on PyPI, and can be useful to help people/programs find things, but I don't think they're used too much. I find it useful to list the Python versions the package has been tested on.
* The dependencies which will also be installed by pip or uv: NumPy and pandas.
* The optional dependencies, when you install with "extras". For example, like we now do on the CI: `pip install .[tests]`. (You may need quotes on macOS: `pip install ".[tests]"`.) This replaces the `requirements.txt` file.
* Some URLs. You can add more here, like `issues` or `documentation`. See also https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels.

To try this out locally:

```
pip install build
python -m build
```

This will create a wheel and sdist in a `dist` directory, for example:

```
starpy-0.0.1-py3-none-any.whl
starpy-0.0.1.tar.gz
```

You can then install these, for example:
```
pip install starpy-0.0.1-py3-none-any.whl
```

And check the library works as expected.

After this, we could set up some a deploy workflow using [Trusted Publishers](https://docs.pypi.org/trusted-publishers/).
